### PR TITLE
Include Google sites in the list of websites to exclude

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -11,7 +11,7 @@
 		{
 			"matches": ["http://*/*", "https://*/*"],
 			"js": ["jquery.js", "jquery.hotkeys.js", "content.js"],
-			"exclude_globs":  ["https://plus.google.com/*", "https://docs.google.com/*"]
+			"exclude_globs":  ["https://plus.google.com/*", "https://docs.google.com/*", "https://sites.google.com/*"]
 		}
 	]
 }


### PR DESCRIPTION
Google Sites is just like Plus and Docs in taking over the backspace key so BackStop will prevent the backspace key from working on these domains
