### PR TITLE
BackStop fix to allow backspace to work in node-inspector

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,21 +1,26 @@
-$(document).keydown(function(e) {
-	// If backspace is pressed
-	if (e.which === 8) {
-		var active = $(document.activeElement);
-		
-		notEditable = function(element) {
-			var edit = element.attr('contenteditable');
+
+(function () {
+	var isWebInspector = !!$('body#-webkit-web-inspector');
+	$(document).keydown(function(e) {
+		// If backspace is pressed
+		if (e.which === 8) {
+			var active = $(document.activeElement);
 			
-			// Ensure backspace still works on any element with contenteditable="true"
-			if (typeof edit !== 'undefined' && edit !== false) {
-				return true;
-			} else if (element.is('input, textarea')) {
-				return true;
+			notEditable = function(element) {
+				var edit = element.attr('contenteditable');
+				// Ensure backspace still works on any element with contenteditable="true"
+				if (typeof edit !== 'undefined' && edit !== false) {
+					return true;
+				} else if (element.is('input, textarea')) {
+					return true;
+				} else if (isWebInspector && (element.attr('id') === 'console-prompt')) {
+					return true;
+				}
+				
+				return false;
 			}
 			
-			return false;
+			return notEditable(active);
 		}
-		
-		return notEditable(active);
-	}
-});
+	});
+}());

--- a/content.js
+++ b/content.js
@@ -8,6 +8,7 @@
 			
 			notEditable = function(element) {
 				var edit = element.attr('contenteditable');
+
 				// Ensure backspace still works on any element with contenteditable="true"
 				if (typeof edit !== 'undefined' && edit !== false) {
 					return true;

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"name": "BackStop",
 	"description": "Stop Backspace returning to previous page.",
-	"version": "2.0.1",
+	"version": "2.0.2",
 	"manifest_version" : 2,
 	"icons": {
 		"16": "logo16.png",


### PR DESCRIPTION
I was having trouble in [node-inspector](https://github.com/node-inspector/node-inspector) with my backspace key not working. Here's a fix: (Use https://github.com/mjhm/BackStop/compare/cranman:master...master?w=1 to compare without the indenting change.)

BTW Thank you for your plugin, it's helped keep me sane for years.
